### PR TITLE
Avoid calling convertValue on values that have already been converted

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -1,3 +1,9 @@
+export type PropPrimitive = string | number | boolean;
+// This type cannot be implicity converted from a PropPrimitve (or string).
+// This is achieved by adding { readonly __brand: unique symbol }
+// However it is SAFE to explicity cast a PropPrimitive to this type
+export type PropValue = (PropPrimitive | PropPrimitive[]) & { readonly __brand: unique symbol };
+
 /**
  *  Converts the given dictionary into a function, thus we can create apply proxy around it
  * you can use apply() on functions, that's why we should convert dictionaries to functions
@@ -14,17 +20,35 @@ export function obj2fun(object: object): () => void {
   return func;
 }
 
-/* Helper function, convert common values to appropriate JavaScript types. (integer / boolean / list) */
-export function convertValue(value: string) {
-  let retvalue: any;
-  const trimmedvalue = value.trim();
+function convertPrimitive(value: string): PropPrimitive {
   if (value.indexOf(';') !== -1) {
-    retvalue = value.split(';');
-    if (retvalue.slice(-1)[0] === '') retvalue.pop();
-    for (let i = 0; i < retvalue.length; i++) retvalue[i] = convertValue(retvalue[i]);
-  } else if (!isNaN(Number(trimmedvalue)) && trimmedvalue.length) retvalue = Number(trimmedvalue);
+    throw new Error(`The following value was epxected to not be a list: ${value}`);
+  }
+  const trimmedvalue = value.trim();
+  let retvalue: PropPrimitive;
+  if (!isNaN(Number(trimmedvalue)) && trimmedvalue.length) retvalue = Number(trimmedvalue);
   else if (value.toUpperCase() === 'FALSE') retvalue = false;
   else if (value.toUpperCase() === 'TRUE') retvalue = true;
   else retvalue = value;
+  return retvalue;
+}
+
+/* Helper function, convert common values to appropriate JavaScript types. (integer / boolean / list) */
+export function convertValue(value: string): PropValue {
+  let retvalue: PropValue;
+  if (value.indexOf(';') !== -1) {
+    const splitValue = value.split(';');
+    const last = splitValue.slice(-1)[0];
+    if (last === '') {
+      splitValue.pop();
+    }
+    const primitiveList: PropPrimitive[] = [];
+    for (const element of splitValue) {
+      primitiveList.push(convertPrimitive(element));
+    }
+    retvalue = primitiveList as PropValue;
+  } else {
+    retvalue = convertPrimitive(value) as PropValue;
+  }
   return retvalue;
 }

--- a/src/noodle.ts
+++ b/src/noodle.ts
@@ -1,8 +1,9 @@
+import { PropValue } from './common';
 import { LwClient } from './lwclient';
 import { LwServer } from './lwserver';
 import { ServerConnection } from './serverconnection';
 
-export type ListenerCallback = (path: string, property: string, value: any) => void;
+export type ListenerCallback = (path: string, property: string, value: PropValue) => void;
 
 export type Noodle = {
   [method: string]: (...args: any[]) => string;


### PR DESCRIPTION
I encountered an exception (trim is not a function), when convertValue is called on a value that has been converted before (an array).
This occured at this line: https://github.com/fejesd/lwnoodle/blob/d0d059be99481a534333b325aeacf3e70007be74/src/lwclient.ts#L326

To prevent this error in the future, a new type `PropValue` is introduced to allow differentiating between raw strings and values that have already been converted.